### PR TITLE
Support ppc64 events

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -37,7 +37,8 @@ ORACLE_SRCS	= oracle.c \
 		  util.c \
 		  sd-boot.c \
 		  uapi.c \
-		  secure_boot.c
+		  secure_boot.c \
+		  ieee1275-events.c
 ORACLE_OBJS	= $(addprefix build/,$(patsubst %.c,%.o,$(ORACLE_SRCS)))
 
 all: $(TOOLS) $(MANPAGES)

--- a/Makefile.in
+++ b/Makefile.in
@@ -3,9 +3,11 @@ PKGNAME		= pcr-oracle-$(VERSION)
 
 CCOPT		= -O0 -g
 FIRSTBOOTDIR	= /usr/share/jeos-firstboot
-CFLAGS		= -Wall @TSS2_ESYS_CFLAGS@ @JSON_CFLAGS@ $(CCOPT)
+CFLAGS		= -Wall @TSS2_ESYS_CFLAGS@ @JSON_CFLAGS@ @FDISK_CFLAGS@ @LIBELF_CFLAGS@ $(CCOPT)
 TSS2_LINK	= -ltss2-esys -ltss2-tctildr -ltss2-rc -ltss2-mu -lcrypto
 JSON_LINK	= -L@JSON_LIBDIR@ @JSON_LIBS@
+FDISK_LINK	= @FDISK_LIBS@
+LIBELF_LINK	= @LIBELF_LIBS@
 TOOLS		= pcr-oracle
 
 MANDIR		= @MANDIR@
@@ -54,7 +56,7 @@ clean:
 	rm -rf build
 
 pcr-oracle: $(ORACLE_OBJS)
-	$(CC) -o $@ $(ORACLE_OBJS) $(TSS2_LINK) $(JSON_LINK)
+	$(CC) -o $@ $(ORACLE_OBJS) $(TSS2_LINK) $(JSON_LINK) $(FDISK_LINK) $(LIBELF_LINK)
 
 build/%.o: src/%.c
 	@mkdir -p build

--- a/configure
+++ b/configure
@@ -15,6 +15,8 @@
 # version 0.5.6
 # require libtss2
 # require json
+# require libfdisk
+# require libelf
 # disable debug-authenticode
 # microconf:end
 

--- a/microconf/stage1/04-fdisk
+++ b/microconf/stage1/04-fdisk
@@ -1,0 +1,11 @@
+uc_add_option_with libfdisk
+uc_with_libfdisk=detect
+
+uc_add_help <<EOH
+
+
+  Override libfdisk detection
+        --with-libfdisk=VERSION
+        --without-libfdisk
+
+EOH

--- a/microconf/stage1/05-libelf
+++ b/microconf/stage1/05-libelf
@@ -1,0 +1,11 @@
+uc_add_option_with libelf
+uc_with_libelf=detect
+
+uc_add_help <<EOH
+
+
+  Override libelf detection
+        --with-libelf=VERSION
+        --without-libelf
+
+EOH

--- a/microconf/stage3/06-fdisk
+++ b/microconf/stage3/06-fdisk
@@ -1,0 +1,6 @@
+##################################################################
+# libfdisk version
+##################################################################
+if [ -z "$uc_with_libfdisk" -o "$uc_with_libfdisk" = "detect" ]; then
+	uc_pkg_config_check_package fdisk
+fi

--- a/microconf/stage3/07-libelf
+++ b/microconf/stage3/07-libelf
@@ -1,0 +1,6 @@
+##################################################################
+# libelf version
+##################################################################
+if [ -z "$uc_with_libelf" -o "$uc_with_libelf" = "detect" ]; then
+	uc_pkg_config_check_package libelf
+fi

--- a/src/efi-gpt.c
+++ b/src/efi-gpt.c
@@ -39,6 +39,7 @@ static const tpm_evdigest_t *	__tpm_event_efi_gpt_rehash(const tpm_event_t *, co
 static void
 __tpm_event_efi_gpt_destroy(tpm_parsed_event_t *parsed)
 {
+	drop_string(&parsed->efi_gpt_event.sys_partition);
 	drop_string(&parsed->efi_gpt_event.disk_device);
 }
 
@@ -166,14 +167,14 @@ __tpm_event_efi_gpt_rehash(const tpm_event_t *ev, const tpm_parsed_event_t *pars
 	buffer_t *buffer = NULL;
 	char *device;
 
-	if (evspec->efi_partition == NULL) {
-		error("Cannot determine EFI partition from event log\n");
+	if (evspec->sys_partition == NULL) {
+		error("Cannot determine system partition from event log\n");
 		/* FIXME: just use the device that holds /boot/efi? */
 		return NULL;
 	}
 
-	if (!(device = runtime_disk_for_partition(evspec->efi_partition))) {
-		error("Unable to determine disk for partition %s\n", evspec->efi_partition);
+	if (!(device = runtime_disk_for_partition(evspec->sys_partition))) {
+		error("Unable to determine disk for partition %s\n", evspec->sys_partition);
 		return NULL;
 	}
 

--- a/src/eventlog.c
+++ b/src/eventlog.c
@@ -1146,6 +1146,9 @@ __tpm_event_parse(tpm_event_t *ev, tpm_parsed_event_t *parsed, tpm_event_log_sca
 
 	case TPM2_EFI_GPT_EVENT:
 		return __tpm_event_parse_efi_gpt(ev, parsed, &buf);
+
+	case TPM2_EVENT_COMPACT_HASH:
+		return __tpm_event_parse_compact_hash(ev, parsed, &buf);
 	}
 
 	return false;

--- a/src/eventlog.c
+++ b/src/eventlog.c
@@ -1089,6 +1089,8 @@ __tpm_event_parse_tag(tpm_event_t *ev, tpm_parsed_event_t *parsed, buffer_t *bp)
 	return true;
 }
 
+#define GRUB_PREP_ENVBLK "PReP ENV Block"
+
 static bool
 __tpm_event_parse_ipl(tpm_event_t *ev, tpm_parsed_event_t *parsed, buffer_t *bp)
 {
@@ -1109,8 +1111,12 @@ __tpm_event_parse_ipl(tpm_event_t *ev, tpm_parsed_event_t *parsed, buffer_t *bp)
 	if (ev->pcr_index == 8)
 		return __tpm_event_grub_command_event_parse(ev, parsed, value);
 
-	if (ev->pcr_index == 9)
-		return __tpm_event_grub_file_event_parse(ev, parsed, value);
+	if (ev->pcr_index == 9) {
+		if (strncmp(value, GRUB_PREP_ENVBLK, strlen(GRUB_PREP_ENVBLK)) == 0)
+			return __tpm_event_grub_envblk_event_parse(ev, parsed, value);
+		else
+			return __tpm_event_grub_file_event_parse(ev, parsed, value);
+	}
 
 	if (ev->pcr_index == 12)
 		return __tpm_event_systemd_event_parse(ev, parsed, value, len);

--- a/src/eventlog.h
+++ b/src/eventlog.h
@@ -295,6 +295,10 @@ typedef struct tpm_parsed_event {
 		struct compact_hash_event {
 			char *		prep_partition;
 		} compact_hash_event;
+
+		struct grub_envblk_event {
+			char *		prep_partition;
+		} grub_envblk_event;
 	};
 } tpm_parsed_event_t;
 
@@ -349,4 +353,5 @@ extern const char *		shim_variable_get_full_rtname(const char *name);
 extern bool			secure_boot_enabled();
 
 extern bool			__tpm_event_parse_compact_hash(tpm_event_t *, tpm_parsed_event_t *, buffer_t *);
+extern bool			__tpm_event_grub_envblk_event_parse(tpm_event_t *, tpm_parsed_event_t *, const char *);
 #endif /* EVENTLOG_H */

--- a/src/eventlog.h
+++ b/src/eventlog.h
@@ -277,7 +277,7 @@ typedef struct tpm_parsed_event {
 		} shim_event;
 
 		struct efi_gpt_event {
-			char *		efi_partition;
+			char *		sys_partition;
 			char *		disk_device;
 		} efi_gpt_event;
 

--- a/src/eventlog.h
+++ b/src/eventlog.h
@@ -291,6 +291,10 @@ typedef struct tpm_parsed_event {
 			uint32_t	event_data_len;
 			char		event_data[52];
 		} tag_event;
+
+		struct compact_hash_event {
+			char *		prep_partition;
+		} compact_hash_event;
 	};
 } tpm_parsed_event_t;
 
@@ -344,4 +348,5 @@ extern const char *		shim_variable_get_full_rtname(const char *name);
 
 extern bool			secure_boot_enabled();
 
+extern bool			__tpm_event_parse_compact_hash(tpm_event_t *, tpm_parsed_event_t *, buffer_t *);
 #endif /* EVENTLOG_H */

--- a/src/ieee1275-events.c
+++ b/src/ieee1275-events.c
@@ -1,0 +1,86 @@
+/*
+ *   Copyright (C) 2025 SUSE LLC
+ *
+ *   This program is free software; you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation; either version 2 of the License, or
+ *   (at your option) any later version.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with this program; if not, write to the Free Software
+ *   Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ *
+ * Written by Gary Lin <glin@suse.com>
+ */
+
+#include <stdbool.h>
+
+#include "bufparser.h"
+#include "eventlog.h"
+#include "runtime.h"
+
+/* Process Compact Hash Events */
+
+static void
+__tpm_event_compact_hash_destroy(tpm_parsed_event_t *parsed)
+{
+	drop_string(&parsed->compact_hash_event.prep_partition);
+}
+
+static const char *
+__tpm_event_compact_hash_describe(const tpm_parsed_event_t *parsed)
+{
+	return "Compact Hash";
+}
+
+static const tpm_evdigest_t *
+__prep_bootloader_rehash (const struct compact_hash_event *evspec, tpm_event_log_rehash_ctx_t *ctx)
+{
+	const tpm_evdigest_t *md;
+
+	debug("Computing digest of the bootloader in PReP partition\n");
+	if (evspec->prep_partition == NULL)
+		return NULL;
+
+	md = runtime_digest_prep_booloader(ctx->algo, evspec->prep_partition);
+
+	return md;
+}
+
+static const tpm_evdigest_t *
+__tpm_event_compact_hash_rehash(const tpm_event_t *ev, const tpm_parsed_event_t *parsed, tpm_event_log_rehash_ctx_t *ctx)
+{
+	const struct compact_hash_event *evspec = &parsed->compact_hash_event;
+
+	/* Copy the digest for the normal Compact Hash events */
+	if (evspec->prep_partition == NULL)
+		return tpm_event_get_digest(ev, ctx->algo);
+
+	/* Rehash the bootloader in the PReP partition */
+	return __prep_bootloader_rehash(evspec, ctx);
+}
+
+bool
+__tpm_event_parse_compact_hash(tpm_event_t *ev, tpm_parsed_event_t *parsed, buffer_t *bp)
+{
+	struct compact_hash_event *evspec = &parsed->compact_hash_event;
+
+	parsed->destroy = __tpm_event_compact_hash_destroy;
+	parsed->describe = __tpm_event_compact_hash_describe;
+	parsed->rehash = __tpm_event_compact_hash_rehash;
+
+	/* Only handle the Compact Hash event with "BOOTLOADER" in the event data */
+	if (bp->size != 10 || memcmp(bp->data, "BOOTLOADER", 10) != 0)
+		return true;
+
+	/* Locate the PReP partition */
+	if (!(evspec->prep_partition = runtime_locate_prep_partition()))
+		return false;
+
+	return true;
+}

--- a/src/oracle.c
+++ b/src/oracle.c
@@ -585,6 +585,12 @@ predictor_get_event_strategy(unsigned int event_type)
 		 */
 		TPM2_EFI_GPT_EVENT,
 
+		/*
+		 * EVENT_COMPACT_HASH: used by SLOF for PCR4, to measure the bootloader with
+		 *	'BOOTLOADER' in the event data.
+		 */
+		TPM2_EVENT_COMPACT_HASH,
+
 		-1,
 	};
 	static int copy_types[] = {

--- a/src/runtime.c
+++ b/src/runtime.c
@@ -473,6 +473,9 @@ runtime_locate_prep_partition(void)
 	char *devname = NULL;
 	char *prep_tmp = NULL;
 
+	if (testcase_playback)
+		return testcase_playback_prep_partition(testcase_playback);
+
 	if (prep_dev[0] != '\0')
 		return strdup(prep_dev);
 
@@ -486,6 +489,8 @@ runtime_locate_prep_partition(void)
 		}
 	}
 
+	if (testcase_recording)
+		testcase_record_prep_partition(testcase_recording, prep_tmp);
 	return prep_tmp;
 }
 

--- a/src/runtime.h
+++ b/src/runtime.h
@@ -40,13 +40,15 @@ extern buffer_t *	runtime_read_efi_variable(const char *var_name);
 extern buffer_t *	runtime_read_efi_application(const char *partition, const char *application);
 extern const tpm_evdigest_t *runtime_digest_efi_file(const tpm_algo_info_t *algo, const char *path);
 extern const tpm_evdigest_t *runtime_digest_rootfs_file(const tpm_algo_info_t *algo, const char *path);
+extern char *		runtime_locate_prep_partition(void);
+extern const tpm_evdigest_t *runtime_digest_prep_booloader(const tpm_algo_info_t *algo, const char *prep_partition);
 extern char *		runtime_disk_for_partition(const char *part_dev);
 extern char *		runtime_blockdev_by_partuuid(const char *uuid);
 extern block_dev_io_t *	runtime_blockdev_open(const char *dev);
-extern buffer_t *	runtime_blockdev_read_lba(block_dev_io_t *, unsigned int block, unsigned int count);
+extern buffer_t *	runtime_blockdev_read_lba(block_dev_io_t *, size_t block, size_t count);
 extern void		runtime_blockdev_close(block_dev_io_t *);
 
-extern unsigned int	runtime_blockdev_bytes_to_sectors(const block_dev_io_t *, unsigned int size);
+extern size_t		runtime_blockdev_bytes_to_sectors(const block_dev_io_t *, size_t size);
 
 extern void		runtime_record_testcase(testcase_t *);
 extern void		runtime_replay_testcase(testcase_t *);

--- a/src/runtime.h
+++ b/src/runtime.h
@@ -42,6 +42,7 @@ extern const tpm_evdigest_t *runtime_digest_efi_file(const tpm_algo_info_t *algo
 extern const tpm_evdigest_t *runtime_digest_rootfs_file(const tpm_algo_info_t *algo, const char *path);
 extern char *		runtime_locate_prep_partition(void);
 extern const tpm_evdigest_t *runtime_digest_prep_booloader(const tpm_algo_info_t *algo, const char *prep_partition);
+extern const tpm_evdigest_t *runtime_digest_prep_envblk(const tpm_algo_info_t *algo, const char *prep_partition);
 extern char *		runtime_disk_for_partition(const char *part_dev);
 extern char *		runtime_blockdev_by_partuuid(const char *uuid);
 extern block_dev_io_t *	runtime_blockdev_open(const char *dev);

--- a/src/testcase.c
+++ b/src/testcase.c
@@ -190,7 +190,8 @@ testcase_read_symlink(const char *directory, const char *name, const char *defau
 		fatal("Cannot read symlink %s: %m\n", path);
 
 	if (target[0] != '/' && default_dir) {
-		snprintf(result, sizeof(result), "%s/%s", default_dir, target);
+		if (snprintf(result, sizeof(result), "%s/%s", default_dir, target) < 0)
+			return NULL;
 		return strdup(result);
 	}
 

--- a/src/testcase.h
+++ b/src/testcase.h
@@ -47,6 +47,8 @@ extern void			testcase_record_rootfs_digest(testcase_t *, const char *path, cons
 extern const tpm_evdigest_t *	testcase_playback_rootfs_digest(testcase_t *, const char *path, const tpm_algo_info_t *algo);
 extern void			testcase_record_efi_digest(testcase_t *, const char *path, const tpm_evdigest_t *md);
 extern const tpm_evdigest_t *	testcase_playback_efi_digest(testcase_t *, const char *path, const tpm_algo_info_t *algo);
+extern void			testcase_record_prep_partition(testcase_t *, const char *path);
+extern char *			testcase_playback_prep_partition(testcase_t *);
 
 #include <stdio.h>
 


### PR DESCRIPTION
PowerPC 64 VMs can support swtpm and the SLOF firmware follows _TCG PC Client Specific Platform Firmware Profile Specification_ (https://trustedcomputinggroup.org/resource/pc-client-specific-platform-firmware-profile-specification/) to record TPM events. However, the ppc64 bootloader is stored in the PReP partition instead of the EFI system partition, so the measurement of the bootloader is different from that of the UEFI firmware. This series of patches measure the bootloader in the PReP partition to close the gap.

NOTE:
SLOF needs at least the following two patches to support GRUB2 TPM2 key protector properly:
* tpm: Implement firmware API call pass-through-to-tpm https://github.com/aik/SLOF/commit/a8e19fa1268f1ead87a3fdd3b872e3398fef2340
* tpm: Implement firmware API call get-maximum-cmd-size https://github.com/aik/SLOF/commit/4ef07b9071a8601457ac7a55c981a69e03c5ea06

These two patches fix the EFI GPT events in SLOF.
* tcgbios: Fix endianess of NumberOfPartitions https://lists.ozlabs.org/pipermail/slof/2025-April/003000.html
* tcgbios: Only measure size indicated in UEFI partition table header https://lists.ozlabs.org/pipermail/slof/2025-April/003002.html
