### PR TITLE
Fix the string comparison for the alternative event

### DIFF
--- a/src/efi-variable.c
+++ b/src/efi-variable.c
@@ -371,7 +371,7 @@ efi_variable_get_parsed_alt (const tpm_parsed_event_t *parsed)
 
 	var_short_name = parsed->efi_variable_event.variable_name;
 
-	if (!strcmp(var_short_name, "db") || !strcmp(var_short_name, "MokListRT"))
+	if (strcmp(var_short_name, "db") != 0 && strcmp(var_short_name, "MokListRT") != 0)
 		return NULL;
 
 	parsed_alt = malloc(sizeof(tpm_parsed_event_t));


### PR DESCRIPTION
The check for the variable names was wrong and it made pcr-oracle skip the creation of the alternative event. Fix the strcmp statement to check the variable name correctly.