### PR TITLE
Fix unsealing failure when using non default PCR bank

### DIFF
--- a/src/pcr-policy.c
+++ b/src/pcr-policy.c
@@ -477,7 +477,7 @@ __pcr_bank_hash(ESYS_CONTEXT *esys_context, const tpm_pcr_bank_t *bank, TPM2B_DI
 
 	rc = Esys_HashSequenceStart(esys_context, ESYS_TR_NONE, ESYS_TR_NONE, ESYS_TR_NONE,
 			&null_auth,
-			bank->algo_info->tcg_id,
+			TPM2_ALG_SHA256,
 			&sequence_handle);
 
 	if (!tss_check_error(rc, "Esys_HashSequenceStart failed"))


### PR DESCRIPTION
There is a grub2 report (https://github.com/lcp/grub2/issues/4) about key unsealing failure when using a non-default PCR bank, and it turned out that pcr-oracle also had a similar issue. For example:

    # pcr-oracle -A sha384 --input secret --output sealed --from current seal-secret 0,2,4,12
    # pcr-oracle -A sha384 --input sealed --output recovered unseal-secret 0,2,4,12
    ::: took 3.127 sec to create SRK
    WARNING:esys:src/tss2-esys/api/Esys_Unseal.c:295:Esys_Unseal_Finish() Received TPM Error
    ERROR:esys:src/tss2-esys/api/Esys_Unseal.c:98:Esys_Unseal() Esys Finish ErrorCode (0x0000099d)
    Error: Esys_Unseal failed: tpm:session(1):a policy check failed

The fix is quite easy: just use the same hash algorithm as that of StartAuthSession when calculating the PCR bank hash.
Besides, the real fix, there is another commit to remove the obsolete code.