### PR TITLE
Advance the comparison event pointer after comparison

### DIFF
--- a/src/oracle.c
+++ b/src/oracle.c
@@ -983,6 +983,9 @@ compare_events(struct predictor *pred, struct predictor *pred_cmp,
 					return false;
 				}
 			}
+
+			/* Nothing to process. Advance the comparison event pointer */
+			ev_cmp = ev_cmp->next;
 		}
 
 		if (stop) {


### PR DESCRIPTION
After comparing events that share the same PCR index, the comparison event pointer must be advanced. Otherwise, the code incorrectly reuses the same event to evaluate the next item in the sequence.