### PR TITLE
Partially support shim extra files

### DIFF
--- a/src/efi-application.c
+++ b/src/efi-application.c
@@ -43,6 +43,7 @@ static bool			__tpm_event_efi_bsa_extract_location(tpm_parsed_event_t *parsed);
 static bool			__tpm_event_efi_bsa_inspect_image(struct efi_bsa_event *evspec);
 
 static bool			__is_shim_issue(const tpm_event_t *ev, const struct efi_bsa_event *evspec);
+static bool			__is_shim_extra_file(const tpm_event_t *ev, const struct efi_bsa_event *evspec, tpm_event_log_scan_ctx_t *ctx, bool is_fullpath);
 
 static void
 __tpm_event_efi_bsa_destroy(tpm_parsed_event_t *parsed)
@@ -89,6 +90,7 @@ __tpm_event_parse_efi_bsa(tpm_event_t *ev, tpm_parsed_event_t *parsed, buffer_t 
 	struct efi_bsa_event *evspec = &parsed->efi_bsa_event;
 	size_t device_path_len;
 	buffer_t path_buf;
+	bool is_fullpath = false;
 
 	parsed->destroy = __tpm_event_efi_bsa_destroy;
 	parsed->print = __tpm_event_efi_bsa_print;
@@ -109,11 +111,12 @@ __tpm_event_parse_efi_bsa(tpm_event_t *ev, tpm_parsed_event_t *parsed, buffer_t 
 	 && evspec->efi_application) {
 		/* If a previous BSA event specified a device path with a partition,
 		 * then the next event may omit it. */
-		if (evspec->efi_partition != NULL)
+		if (evspec->efi_partition != NULL) {
 			assign_string(&ctx->efi_partition, evspec->efi_partition);
-		else
+			is_fullpath = true;
+		} else {
 			assign_string(&evspec->efi_partition, ctx->efi_partition);
-		__tpm_event_efi_bsa_inspect_image(evspec);
+		}
 	}
 
 	/* When the shim issue is present the efi_application will be
@@ -124,6 +127,22 @@ __tpm_event_parse_efi_bsa(tpm_event_t *ev, tpm_parsed_event_t *parsed, buffer_t 
 	if (__is_shim_issue(ev, evspec))
 		assign_string(&evspec->efi_partition, ctx->efi_partition);
 
+	/* TPM events for shim extra files do not record the actual file paths
+	 * in their device path payload. Until a reliable method to resolve the
+	 * real paths on disk is implemented, we default to the COPY strategy for
+	 * these events to bypass rehashing.
+	 */
+	if (__is_shim_extra_file(ev, evspec, ctx, is_fullpath)) {
+		ev->rehash_strategy = EVENT_STRATEGY_COPY;
+		evspec->shim_extra_file = true;
+	}
+
+	if (evspec->efi_application) {
+		if (is_fullpath == true && ctx->first_application == NULL)
+			assign_string(&ctx->first_application, evspec->efi_application);
+
+		__tpm_event_efi_bsa_inspect_image(evspec);
+	}
 
 	return true;
 }
@@ -307,6 +326,27 @@ static bool __is_shim_issue(const tpm_event_t *ev, const struct efi_bsa_event *e
 	 * without path.
 	 */
 	return (secure_boot_enabled() && ev->pcr_index == 4 && !evspec->efi_application);
+}
+
+static bool
+__is_shim_extra_file(const tpm_event_t *ev, const struct efi_bsa_event *evspec, tpm_event_log_scan_ctx_t *ctx, bool is_fullpath)
+{
+	/* When secure boot is enabled, shim calls verify_image() to measure
+	 * the extra files (revocations_sbat.efi, revocations_sku.efi, and
+	 * shim_certificate*.efi) into PCR 4.
+	 *
+	 * The device path in these TPM events contains only the file path node.
+	 * Furthermore, this path always points to the shim image itself rather
+	 * than the specific extra file being measured.
+	 */
+	if (is_fullpath || !secure_boot_enabled() || ev->pcr_index != 4
+	 || ctx->first_application == NULL || evspec->efi_application == NULL)
+		return false;
+
+	if (strcmp(ctx->first_application, evspec->efi_application) != 0)
+		return false;
+
+	return true;
 }
 
 static const tpm_evdigest_t *

--- a/src/efi-variable.c
+++ b/src/efi-variable.c
@@ -418,6 +418,15 @@ __tpm_event_efi_variable_rehash(const tpm_event_t *ev, const tpm_parsed_event_t 
 		return NULL;
 
 	if (ev->event_type == TPM2_EFI_VARIABLE_AUTHORITY) {
+		/* Until we can reliably resolve the actual file path of a shim extra
+		 * file, we cannot extract its signer to verify this
+		 * TPM2_EFI_VARIABLE_AUTHORITY event.
+		 */
+		if (ctx->next_is_extra_file) {
+			md = tpm_event_get_digest(ev, algo);
+			goto out;
+		}
+
 		/* For certificate related variables, EFI_VARIABLE_AUTHORITY events don't return the
 		 * entire DB, but only the record that was used in verifying the application's
 		 * authenticode signature. */

--- a/src/eventlog.h
+++ b/src/eventlog.h
@@ -195,6 +195,7 @@ enum {
  */
 typedef struct tpm_event_log_scan_ctx {
 	char *			efi_partition;
+	char *			first_application;
 } tpm_event_log_scan_ctx_t;
 
 /*
@@ -208,6 +209,7 @@ typedef struct tpm_event_log_rehash_ctx {
 	bool			use_pesign;		/* compute authenticode FP using external pesign application */
 
 	const pecoff_image_info_t *next_stage_img;
+	bool			next_is_extra_file;
 
 	/* This get set when the user specifies --next-kernel */
 	char *			boot_entry_path;
@@ -255,6 +257,8 @@ typedef struct tpm_parsed_event {
 			/* extracted from device_path: */
 			char *		efi_partition;
 			char *		efi_application;
+
+			bool		shim_extra_file;
 
 			/* If we can find an on-disk EFI application for it, try to
 			 * inspect the PECOFF image and extract useful stuff. */

--- a/src/oracle.c
+++ b/src/oracle.c
@@ -559,6 +559,7 @@ __predictor_lookahead_shim_loaded(tpm_event_t *ev, tpm_event_log_rehash_ctx_t *c
 				parsed->efi_bsa_event.efi_partition,
 				parsed->efi_bsa_event.efi_application);
 		ctx->next_stage_img = parsed->efi_bsa_event.img_info;
+		ctx->next_is_extra_file = parsed->efi_bsa_event.shim_extra_file;
 
 #ifdef TESTING_ONLY
 		if (ctx->next_stage_img) {


### PR DESCRIPTION
When Secure Boot is enabled, shim automatically loads specific extra files from its directory: revocations_sbat.efi, revocations_sku.efi, and any EFI files with the shim_certificate prefix. However, the corresponding TPM events do not record the actual file paths, so we cannot locate these files directly from the event log.

To partially support these measurements, this commit sets the rehash strategy to COPY for these events, ensuring that pcr-oracle can at least accurately reproduce the PCR values.

Ref: https://github.com/openSUSE/pcr-oracle/issues/4