### PR TITLE
Locate shim extra files

### DIFF
--- a/src/efi-application.c
+++ b/src/efi-application.c
@@ -84,6 +84,119 @@ __tpm_event_efi_bsa_describe(const tpm_parsed_event_t *parsed)
 	return result;
 }
 
+static char *
+__extract_efi_directory(const char *efi_application)
+{
+	char *efi_directory = NULL;
+	char *last_slash;
+
+	if (efi_application == NULL)
+		return NULL;
+
+	efi_directory = strdup(efi_application);
+	if (efi_directory == NULL) {
+		error("Failed to allocate memory for efi directory\n");
+		return NULL;
+	}
+
+	last_slash = strrchr(efi_directory, '/');
+	if (last_slash == NULL) {
+		error("Invalid path\n");
+		free(efi_directory);
+		return NULL;
+	}
+
+	if (last_slash == efi_directory)
+		*(last_slash + 1) = '\0';
+	else
+		*last_slash = '\0';
+
+	return efi_directory;
+}
+
+static file_list_t *
+__shim_extra_files_init(const struct efi_bsa_event *evspec)
+{
+	file_list_t *head = NULL, *tail, *node;
+	buffer_t *raw_list = NULL;
+	char *efi_directory;
+	const char *str_ptr;
+	char filename[PATH_MAX];
+	char filepath[PATH_MAX];
+	int offset = 0;
+	int ret;
+
+	if (evspec->efi_partition == NULL || evspec->efi_application == NULL)
+		return NULL;
+
+	efi_directory = __extract_efi_directory(evspec->efi_application);
+	if (efi_directory == NULL) {
+		error("unable to extract directory\n");
+		return NULL;
+	}
+
+	raw_list = runtime_read_efi_directory(evspec->efi_partition, efi_directory);
+	if (raw_list == NULL || raw_list->size <= 2) {
+		debug("Empty directory (%s)\n", efi_directory);
+		goto out;
+	}
+	str_ptr = buffer_read_pointer(raw_list);
+
+	/* Shim loads and measures extra files in the exact order they appear in
+	 * the directory. We must preserve this file system order when building our
+	 * list to accurately predict the PCR sequence.
+	 */
+	while(sscanf(str_ptr, "%[^\n]\n%n", filename, &offset) == 1) {
+		str_ptr += offset;
+
+		if (strcasecmp(filename, "revocations_sbat.efi") == 0 ||
+		    strcasecmp(filename, "revocations_sku.efi") == 0 ||
+		    (strncasecmp(filename, "shim_certificate", 16) == 0 &&
+		     path_has_file_extension(filename, ".efi"))) {
+
+			node = calloc(1, sizeof(file_list_t));
+			if (node == NULL) {
+				error("Failed to allocate a file_list_t node\n");
+				goto out;
+			}
+
+			/* Construct the full file path */
+			ret = snprintf(filepath, sizeof(filepath), "%s/%s", efi_directory, filename);
+			if (ret >= sizeof(filepath)) {
+				error("File path too long: (%s/%s)\n", efi_directory, filename);
+				goto out;
+			}
+
+			node->filepath = strdup(filepath);
+			if (node->filepath == NULL) {
+				error("Failed to duplicate filepath(%s)\n", filepath);
+				goto out;
+			}
+
+			/* Append the filepath to the list */
+			if (head) {
+				tail->next = node;
+				tail = node;
+			} else {
+				head = node;
+				tail = node;
+			}
+		}
+
+		if (*str_ptr == '\0')
+			break;
+	}
+
+out:
+	if (efi_directory)
+		free(efi_directory);
+
+	if (raw_list)
+		buffer_free(raw_list);
+
+	return head;
+}
+
 bool
 __tpm_event_parse_efi_bsa(tpm_event_t *ev, tpm_parsed_event_t *parsed, buffer_t *bp, tpm_event_log_scan_ctx_t *ctx)
 {
@@ -128,13 +241,36 @@ __tpm_event_parse_efi_bsa(tpm_event_t *ev, tpm_parsed_event_t *parsed, buffer_t 
 		assign_string(&evspec->efi_partition, ctx->efi_partition);
 
 	/* TPM events for shim extra files do not record the actual file paths
-	 * in their device path payload. Until a reliable method to resolve the
-	 * real paths on disk is implemented, we default to the COPY strategy for
-	 * these events to bypass rehashing.
+	 * in their device path payload. We have to scan the directory of the
+	 * shim image to locate the actual extra files.
 	 */
 	if (__is_shim_extra_file(ev, evspec, ctx, is_fullpath)) {
-		ev->rehash_strategy = EVENT_STRATEGY_COPY;
-		evspec->shim_extra_file = true;
+		/* Get the shim extra file list on demand */
+		if (ctx->shim_extra.head == NULL) {
+			file_list_t *list;
+
+			list = __shim_extra_files_init(evspec);
+			if (list == NULL) {
+				error("Failed to get shim extra file list\n");
+				return false;
+			}
+
+			ctx->shim_extra.head = list;
+			ctx->shim_extra.cur = list;
+		}
+
+		/* Replace evspec->efi_application with the most likely file path
+		 * for the extra file.
+		 */
+		if (ctx->shim_extra.cur != NULL) {
+			drop_string(&evspec->efi_application);
+			assign_string(&evspec->efi_application, ctx->shim_extra.cur->filepath);
+			ctx->shim_extra.cur = ctx->shim_extra.cur->next;
+			debug("Update efi_application: %s\n", evspec->efi_application);
+		} else {
+			error("Failed to locate shim extra file\n");
+			return false;
+		}
 	}
 
 	if (evspec->efi_application) {

--- a/src/efi-variable.c
+++ b/src/efi-variable.c
@@ -418,15 +418,6 @@ __tpm_event_efi_variable_rehash(const tpm_event_t *ev, const tpm_parsed_event_t 
 		return NULL;
 
 	if (ev->event_type == TPM2_EFI_VARIABLE_AUTHORITY) {
-		/* Until we can reliably resolve the actual file path of a shim extra
-		 * file, we cannot extract its signer to verify this
-		 * TPM2_EFI_VARIABLE_AUTHORITY event.
-		 */
-		if (ctx->next_is_extra_file) {
-			md = tpm_event_get_digest(ev, algo);
-			goto out;
-		}
-
 		/* For certificate related variables, EFI_VARIABLE_AUTHORITY events don't return the
 		 * entire DB, but only the record that was used in verifying the application's
 		 * authenticode signature. */

--- a/src/eventlog.c
+++ b/src/eventlog.c
@@ -1198,5 +1198,17 @@ tpm_event_log_scan_ctx_init(tpm_event_log_scan_ctx_t *ctx)
 void
 tpm_event_log_scan_ctx_destroy(tpm_event_log_scan_ctx_t *ctx)
 {
+	file_list_t *cur, *next;
+
 	drop_string(&ctx->efi_partition);
+	drop_string(&ctx->first_application);
+
+	cur = ctx->shim_extra.head;
+
+	while (cur != NULL) {
+		next = cur->next;
+		free(cur->filepath);
+		free(cur);
+		cur = next;
+	}
 }

--- a/src/eventlog.h
+++ b/src/eventlog.h
@@ -190,12 +190,23 @@ enum {
 	EVENT_STRATEGY_NO_ACTION,
 };
 
+typedef struct file_list {
+	char * 			filepath;
+	struct file_list *	next;
+} file_list_t;
+
+typedef struct extra_files {
+	file_list_t *		head;
+	file_list_t *		cur;
+} extra_files_t;
+
 /*
  * This is used while scanning the event log.
  */
 typedef struct tpm_event_log_scan_ctx {
 	char *			efi_partition;
 	char *			first_application;
+	extra_files_t 		shim_extra;
 } tpm_event_log_scan_ctx_t;
 
 /*
@@ -209,7 +220,6 @@ typedef struct tpm_event_log_rehash_ctx {
 	bool			use_pesign;		/* compute authenticode FP using external pesign application */
 
 	const pecoff_image_info_t *next_stage_img;
-	bool			next_is_extra_file;
 
 	/* This get set when the user specifies --next-kernel */
 	char *			boot_entry_path;

--- a/src/oracle.c
+++ b/src/oracle.c
@@ -559,7 +559,6 @@ __predictor_lookahead_shim_loaded(tpm_event_t *ev, tpm_event_log_rehash_ctx_t *c
 				parsed->efi_bsa_event.efi_partition,
 				parsed->efi_bsa_event.efi_application);
 		ctx->next_stage_img = parsed->efi_bsa_event.img_info;
-		ctx->next_is_extra_file = parsed->efi_bsa_event.shim_extra_file;
 
 #ifdef TESTING_ONLY
 		if (ctx->next_stage_img) {

--- a/src/runtime.c
+++ b/src/runtime.c
@@ -29,6 +29,7 @@
 #include <limits.h>
 #include <errno.h>
 #include <ctype.h>
+#include <dirent.h>
 
 #include <libelf.h>
 #include <libfdisk.h>
@@ -302,6 +303,79 @@ runtime_read_efi_application(const char *partition, const char *application)
 		testcase_record_efi_application(testcase_recording, partition, application, result);
 
 	return result;
+}
+
+buffer_t *
+runtime_read_efi_directory(const char *partition, const char *directory)
+{
+	file_locator_t *loc;
+	const char *fullpath;
+	DIR *dir;
+	struct dirent *dir_ent;
+	buffer_t *buf = NULL;
+	unsigned int total_len = 0;
+	char newline = '\n';
+	char null = '\0';
+
+	if (testcase_playback)
+		return testcase_playback_efi_directory(testcase_playback, partition, directory);
+
+	loc = runtime_locate_file(partition, directory);
+	if (!loc) {
+		debug("Failed to locate EFI directory: (%s)%s\n", partition, directory);
+		return NULL;
+	}
+
+	fullpath = file_locator_get_full_path(loc);
+	dir = opendir(fullpath);
+	if (!dir) {
+		debug("Failed to open directory: %s\n", fullpath);
+		file_locator_free(loc);
+		return NULL;
+	}
+
+	/* Calculate the exact buffer size needed */
+	while ((dir_ent = readdir(dir)) != NULL) {
+		if (!strcmp(dir_ent->d_name, ".") || !strcmp(dir_ent->d_name, ".."))
+			continue;
+		/* Add the length of the filename plus the newline */
+		total_len += strlen(dir_ent->d_name) + 1;
+	}
+
+	if (total_len == 0) {
+		closedir(dir);
+		file_locator_free(loc);
+		return buffer_alloc_write(0);
+	}
+
+	/* Allocate the exact buffer size needed */
+	buf = buffer_alloc_write(total_len + 1);
+	if (!buf) {
+		error("Out of memory allocating directory buffer\n");
+		closedir(dir);
+		file_locator_free(loc);
+		return NULL;
+	}
+
+	/* Pack the strings plus the newline sequentially into the buffer */
+	rewinddir(dir);
+	while ((dir_ent = readdir(dir)) != NULL) {
+		if (!strcmp(dir_ent->d_name, ".") || !strcmp(dir_ent->d_name, ".."))
+			continue;
+
+		buffer_put(buf, dir_ent->d_name, strlen(dir_ent->d_name));
+		buffer_put(buf, &newline, 1);
+	}
+
+	buffer_put(buf, &null, 1);
+
+	closedir(dir);
+	file_locator_free(loc);
+
+	if (buf && testcase_recording)
+		testcase_record_efi_directory(testcase_recording, partition, directory, buf);
+
+	return buf;
 }
 
 static bool

--- a/src/runtime.h
+++ b/src/runtime.h
@@ -38,6 +38,7 @@ extern buffer_t *	runtime_read_file(const char *pathname, int flags);
 extern bool		runtime_write_file(const char *pathname, buffer_t *);
 extern buffer_t *	runtime_read_efi_variable(const char *var_name);
 extern buffer_t *	runtime_read_efi_application(const char *partition, const char *application);
+extern buffer_t *	runtime_read_efi_directory(const char *partition, const char *directory);
 extern const tpm_evdigest_t *runtime_digest_efi_file(const tpm_algo_info_t *algo, const char *path);
 extern const tpm_evdigest_t *runtime_digest_rootfs_file(const tpm_algo_info_t *algo, const char *path);
 extern char *		runtime_locate_prep_partition(void);

--- a/src/testcase.c
+++ b/src/testcase.c
@@ -353,6 +353,31 @@ testcase_playback_efi_application(testcase_t *tc, const char *partition, const c
 }
 
 void
+testcase_record_efi_directory(testcase_t *tc, const char *partition, const char *directory, const buffer_t *data)
+{
+	char path[PATH_MAX];
+
+	partition = get_basename(partition);
+
+	/* Append a dummy filename to avoid file-vs-directory collisions on the OS.
+	 * This ensures the path correctly resolves to a file inside the requested folder.
+	 */
+	snprintf(path, sizeof(path), "%s/%s/.dir_list", partition, directory);
+	testcase_write_file(tc->bsa_directory, path, data);
+}
+
+buffer_t *
+testcase_playback_efi_directory(testcase_t *tc, const char *partition, const char *directory)
+{
+	char path[PATH_MAX];
+
+	partition = get_basename(partition);
+
+	snprintf(path, sizeof(path), "%s/%s/.dir_list", partition, directory);
+	return testcase_read_file(tc->bsa_directory, path);
+}
+
+void
 testcase_record_partition_uuid(testcase_t *tc, const char *uuid, const char *dev_name)
 {
 	if (!strncmp(dev_name, "/dev/", 5))

--- a/src/testcase.h
+++ b/src/testcase.h
@@ -39,6 +39,8 @@ extern void			testcase_block_dev_close(testcase_block_dev_t *);
 extern int			testcase_playback_sysfs_file(testcase_t *, const char *);
 extern buffer_t *		testcase_playback_efi_variable(testcase_t *, const char *name);
 extern buffer_t *		testcase_playback_efi_application(testcase_t *, const char *partition, const char *application);
+extern void			testcase_record_efi_directory(testcase_t *tc, const char *partition, const char *directory, const buffer_t *data);
+extern buffer_t *		testcase_playback_efi_directory(testcase_t *tc, const char *partition, const char *directory);
 extern char *			testcase_playback_partition_uuid(testcase_t *, const char *uuid);
 extern char *			testcase_playback_partition_disk(testcase_t *, const char *dev_name);
 extern int			testcase_playback_block_dev(testcase_t *, const char *dev_path);


### PR DESCRIPTION
When Secure Boot is enabled, shim measures extra files (e.g., revocations_sbat.efi, revocations_sku.efi, and shim_certificate*.efi) into PCR 4. However, the TPM events for these measurements do not record the actual file paths in their device path payload—they simply point back to the shim image.

Because pcr-oracle cannot extract the real file paths from the event log, it previously had to rely on a fallback COPY strategy to bypass rehashing for these events.

To accurately predict these measurements, pcr-oracle must replicate shim's internal logic: scanning the directory of the shim executable and matching the extra files. Crucially, shim measures these files in file system order, meaning we must preserve the exact sequence in which the directory is read to ensure deterministic and accurate PCR predictions.

This patch series introduces the necessary runtime helpers to scan an EFI directory, updates the testcase framework to serialize these directory reads to preserve file system order during replays, and implements the matching logic to dynamically map the correct file path to the incoming TPM event.

Ref: https://github.com/openSUSE/pcr-oracle/issues/4