### PR TITLE
Synthesize shim extra events

### DIFF
--- a/src/digest.c
+++ b/src/digest.c
@@ -413,6 +413,14 @@ x509_as_buffer(X509 *x509)
 	return bp;
 }
 
+buffer_t *
+parsed_cert_as_buffer(const parsed_cert_t *cert)
+{
+	if (!cert || !cert->x)
+		return NULL;
+	return x509_as_buffer(cert->x);
+}
+
 parsed_cert_t *
 pkcs7_extract_signer(buffer_t *data)
 {

--- a/src/digest.h
+++ b/src/digest.h
@@ -82,5 +82,6 @@ extern void			parsed_cert_free(parsed_cert_t *);
 extern const char *		parsed_cert_subject(const parsed_cert_t *);
 extern const char *		parsed_cert_issuer(const parsed_cert_t *);
 extern bool			parsed_cert_issued_by(const parsed_cert_t *cert, const parsed_cert_t *potential_issuer);
+extern buffer_t *		parsed_cert_as_buffer(const parsed_cert_t *cert);
 
 #endif /* DIGEST_H */

--- a/src/efi-application.c
+++ b/src/efi-application.c
@@ -510,6 +510,33 @@ get_previous_authority_event(tpm_event_t *ev)
 }
 
 static bool
+map_file_to_shim_event(struct efi_bsa_event *evspec, tpm_event_log_scan_ctx_t *ctx)
+{
+	/* Build the shim extra file list for later use */
+	if (ctx->shim_extra.head == NULL) {
+		file_list_t *list = __shim_extra_files_init(evspec);
+		if (list == NULL) {
+			error("Failed to get shim extra file list\n");
+			return false;
+		}
+		ctx->shim_extra.head = list;
+		ctx->shim_extra.cur = list;
+	}
+
+	if (ctx->shim_extra.cur == NULL) {
+		error("Failed to locate shim extra file\n");
+		return false;
+	}
+
+	drop_string(&evspec->efi_application);
+	assign_string(&evspec->efi_application, ctx->shim_extra.cur->filepath);
+	debug("Update efi_application: %s\n", evspec->efi_application);
+	ctx->shim_extra.cur = ctx->shim_extra.cur->next;
+
+	return true;
+}
+
+static bool
 synthesize_shim_extra_events(tpm_event_t *ev, struct efi_bsa_event *evspec, tpm_event_log_scan_ctx_t *ctx)
 {
 	file_list_t *list, *cur;
@@ -602,7 +629,7 @@ deduplicate_main_authority_event(tpm_event_t *ev, struct efi_bsa_event *evspec, 
 	tpm_event_t *auth_ev;
 
 	/* Skip deduplication if it is not necessary */
-	if (!evspec->img_info || !secure_boot_enabled())
+	if (ctx->disable_synthesis || !evspec->img_info || !secure_boot_enabled())
 		return true;
 
 	/* Skip deduplication if there is no signer */
@@ -683,8 +710,15 @@ __tpm_event_parse_efi_bsa(tpm_event_t *ev, tpm_parsed_event_t *parsed, buffer_t 
 	 * events directly from the directory contents to accurately predict
 	 * changes in signer or file count across updates.
 	 */
-	if (__is_shim_extra_file(ev, evspec, ctx, is_fullpath))
-		return synthesize_shim_extra_events(ev, evspec, ctx);
+	if (__is_shim_extra_file(ev, evspec, ctx, is_fullpath)) {
+		if (!ctx->disable_synthesis)
+			return synthesize_shim_extra_events(ev, evspec, ctx);
+
+		/* The event synthesis is disabled. Try to find the real file name
+		 * for this shim extra file event. */
+		if (!map_file_to_shim_event(evspec, ctx))
+			return false;
+	}
 
 	if (!evspec->efi_application)
 		return true;

--- a/src/efi-application.c
+++ b/src/efi-application.c
@@ -142,50 +142,89 @@ __shim_extra_files_init(const struct efi_bsa_event *evspec)
 	}
 	str_ptr = buffer_read_pointer(raw_list);
 
-	/* Shim loads and measures extra files in the exact order they appear in
-	 * the directory. We must preserve this file system order when building our
-	 * list to accurately predict the PCR sequence.
+	/* Pass 1: Shim explicitly searches for and measures revocations_sbat.efi
+	 * first. If found, it stops the search and rewinds the directory.
 	 */
-	while(sscanf(str_ptr, "%[^\n]\n%n", filename, &offset) == 1) {
+	do {
+		if (sscanf(str_ptr, "%[^\n]\n%n", filename, &offset) != 1)
+			break;
 		str_ptr += offset;
 
-		if (strcasecmp(filename, "revocations_sbat.efi") == 0 ||
-		    strcasecmp(filename, "revocations_sku.efi") == 0 ||
-		    (strncasecmp(filename, "shim_certificate", 16) == 0 &&
-		     path_has_file_extension(filename, ".efi"))) {
+		if (strcasecmp(filename, "revocations_sbat.efi") != 0)
+			continue;
 
-			node = calloc(1, sizeof(file_list_t));
-			if (node == NULL) {
-				error("Failed to allocate a file_list_t node\n");
-				goto out;
-			}
-
-			/* Construct the full file path */
-			ret = snprintf(filepath, sizeof(filepath), "%s/%s", efi_directory, filename);
-			if (ret >= sizeof(filepath)) {
-				error("File path too long: (%s/%s)\n", efi_directory, filename);
-				goto out;
-			}
-
-			node->filepath = strdup(filepath);
-			if (node->filepath == NULL) {
-				error("Failed to duplicate filepath(%s)\n", filepath);
-				goto out;
-			}
-
-			/* Append the filepath to the list */
-			if (head) {
-				tail->next = node;
-				tail = node;
-			} else {
-				head = node;
-				tail = node;
-			}
+		node = calloc(1, sizeof(file_list_t));
+		if (node == NULL) {
+			error("Failed to allocate a file_list_t node\n");
+			goto out;
 		}
 
-		if (*str_ptr == '\0')
+		/* Construct the full file path */
+		ret = snprintf(filepath, sizeof(filepath), "%s/%s", efi_directory, filename);
+		if (ret >= sizeof(filepath)) {
+			error("File path too long: (%s/%s)\n", efi_directory, filename);
+			free(node);
+			goto out;
+		}
+		node->filepath = strdup(filepath);
+		if (node->filepath == NULL) {
+			error("Failed to duplicate filepath(%s)\n", filepath);
+			free(node);
+			goto out;
+		}
+
+		/* revocations_sbat.efi is always the first node if exists */
+		head = node;
+		tail = node;
+		break;
+	} while (*str_ptr != '\0');
+
+	/* Pass 2: Shim iterates the directory again from the beginning, ignoring
+	 * the SBAT file, and measures certificates and SKU revocations in raw
+	 * FAT directory order.
+	 */
+	str_ptr = buffer_read_pointer(raw_list);
+	do {
+		if (sscanf(str_ptr, "%[^\n]\n%n", filename, &offset) != 1)
 			break;
-	}
+		str_ptr += offset;
+
+		if (strcasecmp(filename, "revocations_sku.efi") != 0 &&
+		    !(strncasecmp(filename, "shim_certificate", 16) == 0 &&
+		      path_has_file_extension(filename, ".efi"))) {
+			continue;
+		}
+
+		node = calloc(1, sizeof(file_list_t));
+		if (node == NULL) {
+			error("Failed to allocate a file_list_t node\n");
+			goto out;
+		}
+
+		/* Construct the full file path */
+		ret = snprintf(filepath, sizeof(filepath), "%s/%s", efi_directory, filename);
+		if (ret >= sizeof(filepath)) {
+			error("File path too long: (%s/%s)\n", efi_directory, filename);
+			free(node);
+			goto out;
+		}
+
+		node->filepath = strdup(filepath);
+		if (node->filepath == NULL) {
+			error("Failed to duplicate filepath(%s)\n", filepath);
+			free(node);
+			goto out;
+		}
+
+		/* Append the filepath to the list */
+		if (head) {
+			tail->next = node;
+			tail = node;
+		} else {
+			head = node;
+			tail = node;
+		}
+	} while (*str_ptr != '\0');
 
 out:
 	if (efi_directory)

--- a/src/efi-application.c
+++ b/src/efi-application.c
@@ -84,6 +84,41 @@ __tpm_event_efi_bsa_describe(const tpm_parsed_event_t *parsed)
 	return result;
 }
 
+static bool
+__is_data_already_measured(measured_blob_t **head, const buffer_t *data)
+{
+	measured_blob_t *cur = *head;
+	unsigned int len;
+	const void *ptr;
+	measured_blob_t *node;
+
+	if (!data)
+		return false;
+
+	len = buffer_available(data);
+	ptr = buffer_read_pointer(data);
+
+	while (cur != NULL) {
+		if (buffer_available(cur->data) == len &&
+		    memcmp(buffer_read_pointer(cur->data), ptr, len) == 0) {
+			return true;
+		}
+		cur = cur->next;
+	}
+
+	node = calloc(1, sizeof(*node));
+	if (node == NULL) {
+		error("Failed to allocate memory for measured data link\n");
+		return false;
+	}
+	node->data = buffer_alloc_write(len);
+	buffer_put(node->data, ptr, len);
+	node->next = *head;
+	*head = node;
+
+	return false;
+}
+
 static char *
 __extract_efi_directory(const char *efi_application)
 {

--- a/src/efi-application.c
+++ b/src/efi-application.c
@@ -119,6 +119,225 @@ __is_data_already_measured(measured_blob_t **head, const buffer_t *data)
 	return false;
 }
 
+static const tpm_evdigest_t *
+__synthetic_pcr7_rehash(const tpm_event_t *ev, const tpm_parsed_event_t *parsed, tpm_event_log_rehash_ctx_t *ctx)
+{
+	return digest_compute(ctx->algo, parsed->efi_variable_event.data, parsed->efi_variable_event.len);
+}
+
+static const char *
+__synthetic_pcr7_describe(const tpm_parsed_event_t *parsed)
+{
+	return "Synthesized Shim Authority Event";
+}
+
+static void
+__synthetic_pcr7_destroy(tpm_parsed_event_t *parsed)
+{
+	free(parsed->efi_variable_event.data);
+}
+
+static const uint8_t uefi_db_guid[16] =
+	{0xcb, 0xb2, 0x19, 0xd7,
+	 0x3a, 0x3d,
+	 0x96, 0x45,
+	 0xa3, 0xbc,
+	 0xda, 0xd0, 0x0e, 0x67, 0x65, 0x6f};
+
+static const uint8_t shim_variable_guid[16] =
+	{0x50, 0xab, 0x5d, 0x60,
+	 0x46, 0xe0,
+	 0x00, 0x43,
+	 0xab, 0xb6,
+	 0x3d, 0xd8, 0x10, 0xdd, 0x8b, 0x23};
+
+typedef struct {
+	const char *search_name;
+	const char *var_name;
+	const uint8_t *var_guid;
+} db_search_t;
+
+static buffer_t *
+build_shim_authority_payload(const parsed_cert_t *signer)
+{
+	buffer_t *var_data = NULL;
+	const char *var_name = NULL;
+	const uint8_t *var_guid = NULL;
+	uint64_t name_len = 0;
+	buffer_t *bp = NULL;
+	uint64_t i;
+
+	const db_search_t databases[] = {
+		{ "db", "db", uefi_db_guid },
+		{ "MokList", "MokList", shim_variable_guid },
+		{ "shim-vendor-cert", "Shim", shim_variable_guid }
+	};
+
+	for (i = 0; i < sizeof(databases) / sizeof(databases[0]); i++) {
+		var_data = efi_application_locate_authority_record(databases[i].search_name,
+								   signer);
+		if (var_data) {
+			var_name = databases[i].var_name;
+			name_len = strlen(var_name);
+			var_guid = databases[i].var_guid;
+			break;
+		}
+	}
+
+	if (!var_data) {
+		error("Failed to locate authority record for synthetic event\n");
+		return NULL;
+	}
+
+	uint64_t data_len = buffer_available(var_data);
+	bp = buffer_alloc_write(16 + 8 + 8 + name_len * 2 + data_len);
+
+	buffer_put(bp, var_guid, 16);
+	buffer_put_u64le(bp, name_len);
+	buffer_put_u64le(bp, data_len);
+	for (i = 0; i < name_len; i++)
+		buffer_put_u16le(bp, var_name[i]);
+	buffer_copy(var_data, data_len, bp);
+	buffer_free(var_data);
+
+	return bp;
+}
+
+static tpm_event_t *
+synthesize_shim_authority_event(tpm_event_t *inject_after, const parsed_cert_t *signer)
+{
+	tpm_event_t *syn_7;
+	buffer_t *payload = NULL;
+
+	syn_7 = calloc(1, sizeof(*syn_7));
+	if (syn_7 == NULL) {
+		error("Failed to allocate memory for shim Authority event\n");
+		goto err;
+	}
+
+	payload = build_shim_authority_payload(signer);
+	if (!payload) {
+		error("Failed to build shim Authority event payload\n");
+		goto err;
+	}
+
+	syn_7->synthetic = true;
+	syn_7->event_type = TPM2_EFI_VARIABLE_AUTHORITY;
+	syn_7->pcr_index = 7;
+	syn_7->rehash_strategy = EVENT_STRATEGY_PARSE_REHASH;
+
+	syn_7->event_size = buffer_available(payload);
+	syn_7->event_data = malloc(syn_7->event_size);
+	if (syn_7->event_data == NULL) {
+		error("Failed to allocate memory for shim Authority event data\n");
+		goto err;
+	}
+	memcpy(syn_7->event_data, buffer_read_pointer(payload), syn_7->event_size);
+
+	syn_7->__parsed = calloc(1, sizeof(tpm_parsed_event_t));
+	if (syn_7->__parsed == NULL) {
+		error("Failed to allocate memory for parsed shim Authority event\n");
+		goto err;
+	}
+	syn_7->__parsed->describe = __synthetic_pcr7_describe;
+	syn_7->__parsed->rehash = __synthetic_pcr7_rehash;
+	syn_7->__parsed->destroy = __synthetic_pcr7_destroy;
+	syn_7->__parsed->efi_variable_event.len = buffer_available(payload);
+	syn_7->__parsed->efi_variable_event.data = malloc(buffer_available(payload));
+	if (syn_7->__parsed->efi_variable_event.data == NULL) {
+		error("Failed to allocate memory for efi variable event data\n");
+		goto err;
+	}
+	memcpy(syn_7->__parsed->efi_variable_event.data,
+	       buffer_read_pointer(payload),
+	       buffer_available(payload));
+	buffer_free(payload);
+
+	syn_7->next = inject_after->next;
+	syn_7->prev = inject_after;
+	if (inject_after->next)
+		inject_after->next->prev = syn_7;
+	inject_after->next = syn_7;
+	return syn_7;
+
+err:
+	buffer_free(payload);
+
+	if (syn_7 != NULL) {
+		if (syn_7->__parsed != NULL) {
+			free(syn_7->__parsed->efi_variable_event.data);
+			free(syn_7->__parsed);
+		}
+		free(syn_7->event_data);
+		free(syn_7);
+	}
+
+	return inject_after;
+}
+
+static tpm_event_t *
+synthesize_shim_bsa_event(tpm_event_t *inject_after, const char *filepath, tpm_event_log_scan_ctx_t *ctx)
+{
+	tpm_event_t *syn_4 = calloc(1, sizeof(*syn_4));
+
+	if (syn_4 == NULL) {
+		error("Failed to allocate memory for shim BSA event\n");
+		goto err;
+	}
+
+	syn_4->synthetic = true;
+	syn_4->event_type = TPM2_EFI_BOOT_SERVICES_APPLICATION;
+	syn_4->pcr_index = 4;
+	syn_4->rehash_strategy = EVENT_STRATEGY_PARSE_REHASH;
+	if (ctx->shim_event_data_template) {
+		syn_4->event_size = ctx->shim_event_data_size;
+		syn_4->event_data = malloc(syn_4->event_size);
+		if (syn_4->event_data == NULL) {
+			error("Failed to allocate memory for shim BSA event data\n");
+			goto err;
+		}
+		memcpy(syn_4->event_data, ctx->shim_event_data_template, syn_4->event_size);
+	}
+	syn_4->__parsed = calloc(1, sizeof(tpm_parsed_event_t));
+	if (syn_4->__parsed == NULL) {
+		error("Failed to allocate memory for parsed shim BSA event\n");
+		goto err;
+	}
+	syn_4->__parsed->describe = __tpm_event_efi_bsa_describe;
+	syn_4->__parsed->rehash = __tpm_event_efi_bsa_rehash;
+	syn_4->__parsed->destroy = __tpm_event_efi_bsa_destroy;
+	syn_4->__parsed->efi_bsa_event.efi_partition = strdup(ctx->efi_partition);
+	if (syn_4->__parsed->efi_bsa_event.efi_partition == NULL) {
+		error("Failed to duplicate efi_partition for shim BSA event\n");
+		goto err;
+	}
+	syn_4->__parsed->efi_bsa_event.efi_application = strdup(filepath);
+	if (syn_4->__parsed->efi_bsa_event.efi_application == NULL) {
+		error("Failed to duplicate efi_application for shim BSA event\n");
+		goto err;
+	}
+	__tpm_event_efi_bsa_inspect_image(&syn_4->__parsed->efi_bsa_event);
+
+	syn_4->next = inject_after->next;
+	syn_4->prev = inject_after;
+	if (inject_after->next)
+		inject_after->next->prev = syn_4;
+	inject_after->next = syn_4;
+	return syn_4;
+
+err:
+	if (syn_4 != NULL) {
+		if (syn_4->__parsed != NULL) {
+			free(syn_4->__parsed->efi_bsa_event.efi_partition);
+			free(syn_4->__parsed);
+		}
+		free(syn_4->event_data);
+		free(syn_4);
+	}
+
+	return inject_after;
+}
+
 static char *
 __extract_efi_directory(const char *efi_application)
 {
@@ -271,6 +490,151 @@ out:
 	return head;
 }
 
+static tpm_event_t *
+get_previous_authority_event(tpm_event_t *ev)
+{
+	tpm_event_t *prev = ev->prev;
+
+	while (prev) {
+		if (prev->event_type == TPM2_EFI_VARIABLE_AUTHORITY)
+			return prev;
+
+		/* Stop searching if we hit another application or driver load */
+		if (prev->event_type == TPM2_EFI_BOOT_SERVICES_APPLICATION ||
+		    prev->event_type == TPM2_EFI_BOOT_SERVICES_DRIVER)
+			break;
+
+		prev = prev->prev;
+	}
+	return NULL;
+}
+
+static bool
+synthesize_shim_extra_events(tpm_event_t *ev, struct efi_bsa_event *evspec, tpm_event_log_scan_ctx_t *ctx)
+{
+	file_list_t *list, *cur;
+	tpm_event_t *inject_after = ev;
+	tpm_event_t *auth_ev;
+
+	auth_ev = get_previous_authority_event(ev);
+
+	/* Retroactively skip the corresponding PCR 7 event */
+	if (auth_ev)
+		auth_ev->rehash_strategy = EVENT_STRATEGY_NO_ACTION;
+
+	/* Save the original event data payload as a template for synthetic events */
+	if (!ctx->shim_event_data_template && ev->event_data && ev->event_size > 0) {
+		ctx->shim_event_data_template = malloc(ev->event_size);
+		if (ctx->shim_event_data_template == NULL) {
+			error("Failed to allocate memory for shim event template\n");
+			return false;
+		}
+
+		memcpy(ctx->shim_event_data_template, ev->event_data, ev->event_size);
+		ctx->shim_event_data_size = ev->event_size;
+	}
+
+	if (ctx->skip_original_shim_events)
+		goto out;
+
+	list = __shim_extra_files_init(evspec);
+	if (list == NULL) {
+		error("Failed to get shim extra file list\n");
+		return false;
+	}
+
+	ctx->shim_extra.head = list;
+	cur = list;
+
+	while (cur != NULL) {
+		buffer_t *img_data;
+		pecoff_image_info_t *img_info;
+		parsed_cert_t *signer;
+		buffer_t *cert_der;
+
+		img_data = runtime_read_efi_application(ctx->efi_partition, cur->filepath);
+		if (!img_data) {
+			cur = cur->next;
+			continue;
+		}
+
+		img_info = pecoff_inspect(img_data, cur->filepath);
+		if (!img_info) {
+			buffer_free(img_data);
+			cur = cur->next;
+			continue;
+		}
+
+		signer = authenticode_get_signer(img_info);
+		if (signer) {
+			cert_der = parsed_cert_as_buffer(signer);
+			if (!__is_data_already_measured(&ctx->measured_blobs, cert_der)) {
+				inject_after = synthesize_shim_authority_event(inject_after, signer);
+				debug("Synthesized PCR 7 event for signer of %s\n",
+				      cur->filepath);
+			}
+			buffer_free(cert_der);
+			parsed_cert_free(signer);
+		}
+
+		inject_after = synthesize_shim_bsa_event(inject_after, cur->filepath, ctx);
+		debug("Synthesized PCR 4 event for %s\n", cur->filepath);
+
+		pecoff_image_info_free(img_info);
+		cur = cur->next;
+	}
+
+	/* All shim extra file events are synthesized. Skip the original events
+	 * from shim. */
+	ctx->skip_original_shim_events = true;
+
+out:
+	/* Mark the original PCR 4 event as NO ACTION to skip it */
+	ev->rehash_strategy = EVENT_STRATEGY_NO_ACTION;
+	return true;
+}
+
+static bool
+deduplicate_main_authority_event(tpm_event_t *ev, struct efi_bsa_event *evspec, tpm_event_log_scan_ctx_t *ctx)
+{
+	parsed_cert_t *signer;
+	buffer_t *cert_der;
+	tpm_event_t *auth_ev;
+
+	/* Skip deduplication if it is not necessary */
+	if (!evspec->img_info || !secure_boot_enabled())
+		return true;
+
+	/* Skip deduplication if there is no signer */
+	signer = authenticode_get_signer(evspec->img_info);
+	if (signer == NULL)
+		return true;
+
+	cert_der = parsed_cert_as_buffer(signer);
+	if (cert_der == NULL) {
+		error("Failed to fetch signer buffer\n");
+		return false;
+	}
+
+	/* Fetch the corresponding authority event for this application */
+	auth_ev = get_previous_authority_event(ev);
+
+	if (!__is_data_already_measured(&ctx->measured_blobs, cert_der)) {
+		/* Not measured yet. If we don't have the PCR 7 event, synthesize one. */
+		if (auth_ev == NULL && ev->prev != NULL)
+			synthesize_shim_authority_event(ev->prev, signer);
+	} else {
+		/* Already measured. If we have a PCR 7 event for this signer,
+		 * neutralize it. */
+		if (auth_ev)
+			auth_ev->rehash_strategy = EVENT_STRATEGY_NO_ACTION;
+	}
+	buffer_free(cert_der);
+	parsed_cert_free(signer);
+
+	return true;
+}
+
 bool
 __tpm_event_parse_efi_bsa(tpm_event_t *ev, tpm_parsed_event_t *parsed, buffer_t *bp, tpm_event_log_scan_ctx_t *ctx)
 {
@@ -315,46 +679,23 @@ __tpm_event_parse_efi_bsa(tpm_event_t *ev, tpm_parsed_event_t *parsed, buffer_t 
 		assign_string(&evspec->efi_partition, ctx->efi_partition);
 
 	/* TPM events for shim extra files do not record the actual file paths
-	 * in their device path payload. We have to scan the directory of the
-	 * shim image to locate the actual extra files.
+	 * in their device path payload. We synthesize the PCR 4 and PCR 7
+	 * events directly from the directory contents to accurately predict
+	 * changes in signer or file count across updates.
 	 */
-	if (__is_shim_extra_file(ev, evspec, ctx, is_fullpath)) {
-		/* Get the shim extra file list on demand */
-		if (ctx->shim_extra.head == NULL) {
-			file_list_t *list;
+	if (__is_shim_extra_file(ev, evspec, ctx, is_fullpath))
+		return synthesize_shim_extra_events(ev, evspec, ctx);
 
-			list = __shim_extra_files_init(evspec);
-			if (list == NULL) {
-				error("Failed to get shim extra file list\n");
-				return false;
-			}
+	if (!evspec->efi_application)
+		return true;
 
-			ctx->shim_extra.head = list;
-			ctx->shim_extra.cur = list;
-		}
+	if (is_fullpath == true && ctx->first_application == NULL)
+		assign_string(&ctx->first_application, evspec->efi_application);
 
-		/* Replace evspec->efi_application with the most likely file path
-		 * for the extra file.
-		 */
-		if (ctx->shim_extra.cur != NULL) {
-			drop_string(&evspec->efi_application);
-			assign_string(&evspec->efi_application, ctx->shim_extra.cur->filepath);
-			ctx->shim_extra.cur = ctx->shim_extra.cur->next;
-			debug("Update efi_application: %s\n", evspec->efi_application);
-		} else {
-			error("Failed to locate shim extra file\n");
-			return false;
-		}
-	}
+	__tpm_event_efi_bsa_inspect_image(evspec);
 
-	if (evspec->efi_application) {
-		if (is_fullpath == true && ctx->first_application == NULL)
-			assign_string(&ctx->first_application, evspec->efi_application);
-
-		__tpm_event_efi_bsa_inspect_image(evspec);
-	}
-
-	return true;
+	/* Deduplicate PCR 7 Authority event for the main bootloader, e.g. grub2 */
+	return deduplicate_main_authority_event(ev, evspec, ctx);
 }
 
 bool

--- a/src/eventlog.c
+++ b/src/eventlog.c
@@ -1220,4 +1220,7 @@ tpm_event_log_scan_ctx_destroy(tpm_event_log_scan_ctx_t *ctx)
 		free(mcur);
 		mcur = mnext;
 	}
+
+	if (ctx->shim_event_data_template)
+		free(ctx->shim_event_data_template);
 }

--- a/src/eventlog.c
+++ b/src/eventlog.c
@@ -1199,6 +1199,7 @@ void
 tpm_event_log_scan_ctx_destroy(tpm_event_log_scan_ctx_t *ctx)
 {
 	file_list_t *cur, *next;
+	measured_blob_t *mcur, *mnext;
 
 	drop_string(&ctx->efi_partition);
 	drop_string(&ctx->first_application);
@@ -1210,5 +1211,13 @@ tpm_event_log_scan_ctx_destroy(tpm_event_log_scan_ctx_t *ctx)
 		free(cur->filepath);
 		free(cur);
 		cur = next;
+	}
+
+	mcur = ctx->measured_blobs;
+	while (mcur != NULL) {
+		mnext = mcur->next;
+		buffer_free(mcur->data);
+		free(mcur);
+		mcur = mnext;
 	}
 }

--- a/src/eventlog.h
+++ b/src/eventlog.h
@@ -218,6 +218,7 @@ typedef struct tpm_event_log_scan_ctx {
 	bool			skip_original_shim_events;
 	void *			shim_event_data_template;
 	unsigned int		shim_event_data_size;
+	bool			disable_synthesis;
 } tpm_event_log_scan_ctx_t;
 
 /*

--- a/src/eventlog.h
+++ b/src/eventlog.h
@@ -200,6 +200,11 @@ typedef struct extra_files {
 	file_list_t *		cur;
 } extra_files_t;
 
+typedef struct measured_blob {
+	buffer_t *		data;
+	struct measured_blob *	next;
+} measured_blob_t;
+
 /*
  * This is used while scanning the event log.
  */
@@ -207,6 +212,7 @@ typedef struct tpm_event_log_scan_ctx {
 	char *			efi_partition;
 	char *			first_application;
 	extra_files_t 		shim_extra;
+	measured_blob_t *	measured_blobs;
 } tpm_event_log_scan_ctx_t;
 
 /*

--- a/src/eventlog.h
+++ b/src/eventlog.h
@@ -46,6 +46,7 @@ typedef struct tpm_event {
 	int			rehash_strategy;
 
 	tpm_evdigest_t		predicted_digest;
+	bool			synthetic;
 } tpm_event_t;
 
 typedef void			tpm_event_bit_printer(const char *, ...);
@@ -214,6 +215,9 @@ typedef struct tpm_event_log_scan_ctx {
 	char *			first_application;
 	extra_files_t 		shim_extra;
 	measured_blob_t *	measured_blobs;
+	bool			skip_original_shim_events;
+	void *			shim_event_data_template;
+	unsigned int		shim_event_data_size;
 } tpm_event_log_scan_ctx_t;
 
 /*

--- a/src/eventlog.h
+++ b/src/eventlog.h
@@ -25,6 +25,7 @@
 #include "types.h"
 
 typedef struct tpm_event {
+	struct tpm_event *	prev;
 	struct tpm_event *	next;
 
 	unsigned int		event_index;

--- a/src/oracle.c
+++ b/src/oracle.c
@@ -77,6 +77,7 @@ struct predictor {
 	tpm_pcr_bank_t		prediction;
 	bool			pre_scanned;
 	tpm_event_t *		stop_event_ptr;
+	bool			disable_synthesis;
 };
 
 #define GRUB_PCR_SNAPSHOT_PATH	"/sys/firmware/efi/efivars/GrubPcrSnapshot-7ce323f2-b841-4d30-a0e9-5474a76c9a3f"
@@ -107,6 +108,7 @@ enum {
 	OPT_BOOT_ENTRY,
 	OPT_COMPARE_CURRENT,
 	OPT_PERSISTENT_SRK,
+	OPT_DISABLE_SYNTHESIS,
 };
 
 static struct option options[] = {
@@ -143,6 +145,7 @@ static struct option options[] = {
 	{ "next-kernel",	required_argument,	0,	OPT_BOOT_ENTRY },
 	{ "compare-current",	no_argument,		0,	OPT_COMPARE_CURRENT },
 	{ "persistent-srk",	required_argument,	0,	OPT_PERSISTENT_SRK },
+	{ "disable-synthesis",	no_argument,		0,	OPT_DISABLE_SYNTHESIS },
 
 	{ NULL }
 };
@@ -186,6 +189,8 @@ usage(int exitval, const char *msg)
 		"  --verify SOURCE        After applying all updates, compare the prediction against the given SOURCE (see below).\n"
 		"  --tpm-eventlog PATH\n"
 		"                         Specify a different TPM event log to process.\n"
+		"  --disable-synthesis\n"
+		"                         Disable predictive event synthesis and deduplication for shim extra files.\n"
 		"\n"
 		"The pcr-index argument can be one or more PCR indices or index ranges, separated by comma.\n"
 		"Using \"all\" selects all applicable PCR registers.\n"
@@ -671,6 +676,7 @@ predictor_pre_scan_eventlog(struct predictor *pred, tpm_event_t **stop_event_p)
 	*stop_event_p = NULL;
 
 	tpm_event_log_scan_ctx_init(&scan_ctx);
+	scan_ctx.disable_synthesis = pred->disable_synthesis;
 	for (ev = pred->event_log; ev; ev = ev->next) {
 
 		if (ev->synthetic)
@@ -1200,6 +1206,7 @@ main(int argc, char **argv)
 	char *opt_boot_entry = NULL;
 	bool opt_compare_current = false;
 	char *opt_persistent_srk = NULL;
+	bool opt_disable_synthesis = false;
 	const target_platform_t *target;
 	unsigned int action_flags = 0;
 	unsigned int rsa_bits = 2048;
@@ -1308,6 +1315,9 @@ main(int argc, char **argv)
 			break;
 		case OPT_PERSISTENT_SRK:
 			opt_persistent_srk = optarg;
+			break;
+		case OPT_DISABLE_SYNTHESIS:
+			opt_disable_synthesis = true;
 			break;
 		case 'h':
 			usage(0, NULL);
@@ -1495,6 +1505,7 @@ main(int argc, char **argv)
 
 	pred = predictor_new(pcr_selection, opt_from, opt_eventlog_path,
 			opt_output_format, opt_boot_entry);
+	pred->disable_synthesis = opt_disable_synthesis;
 
 	if (opt_stop_event)
 		predictor_set_stop_event(pred, opt_stop_event, !opt_stop_before);

--- a/src/oracle.c
+++ b/src/oracle.c
@@ -75,6 +75,8 @@ struct predictor {
 	void			(*report_fn)(struct predictor *, unsigned int);
 
 	tpm_pcr_bank_t		prediction;
+	bool			pre_scanned;
+	tpm_event_t *		stop_event_ptr;
 };
 
 #define GRUB_PCR_SNAPSHOT_PATH	"/sys/firmware/efi/efivars/GrubPcrSnapshot-7ce323f2-b841-4d30-a0e9-5474a76c9a3f"
@@ -661,6 +663,11 @@ predictor_pre_scan_eventlog(struct predictor *pred, tpm_event_t **stop_event_p)
 	tpm_event_log_scan_ctx_t scan_ctx;
 	tpm_event_t *ev;
 
+	if (pred->pre_scanned) {
+		*stop_event_p = pred->stop_event_ptr;
+		return;
+	}
+
 	*stop_event_p = NULL;
 
 	tpm_event_log_scan_ctx_init(&scan_ctx);
@@ -693,6 +700,9 @@ predictor_pre_scan_eventlog(struct predictor *pred, tpm_event_t **stop_event_p)
 		}
 	}
 	tpm_event_log_scan_ctx_destroy(&scan_ctx);
+
+	pred->pre_scanned = true;
+	pred->stop_event_ptr = *stop_event_p;
 }
 
 static bool
@@ -963,6 +973,9 @@ compare_events(struct predictor *pred, struct predictor *pred_cmp,
 			debug("Stopped processing event log before indicated event\n");
 			break;
 		}
+
+		if (ev->rehash_strategy == EVENT_STRATEGY_NO_ACTION)
+			continue;
 
 		if (ev->pcr_index == pcr_index) {
 			/* Advance the event in the comparison event log */

--- a/src/oracle.c
+++ b/src/oracle.c
@@ -665,6 +665,10 @@ predictor_pre_scan_eventlog(struct predictor *pred, tpm_event_t **stop_event_p)
 
 	tpm_event_log_scan_ctx_init(&scan_ctx);
 	for (ev = pred->event_log; ev; ev = ev->next) {
+
+		if (ev->synthetic)
+			continue;
+
 		ev->rehash_strategy = predictor_get_event_strategy(ev->event_type);
 		/* debug("%s -> %d\n", tpm_event_type_to_string(ev->event_type), ev->rehash_strategy); */
 
@@ -735,7 +739,7 @@ predictor_update_eventlog(struct predictor *pred)
 			debug("\n");
 			__tpm_event_print(ev, debug);
 
-			if (!(old_digest = tpm_event_get_digest(ev, pred->algo_info)))
+			if (!ev->synthetic && !(old_digest = tpm_event_get_digest(ev, pred->algo_info)))
 				fatal("Event log lacks a hash for digest algorithm %s\n", pred->algo);
 
 			if (false) {
@@ -787,6 +791,7 @@ predictor_update_eventlog(struct predictor *pred)
 				break;
 
 			case EVENT_STRATEGY_NO_ACTION:
+				debug("Skipping event (EVENT_STRATEGY_NO_ACTION)\n");
 				goto no_action;
 
 			default:
@@ -803,14 +808,19 @@ predictor_update_eventlog(struct predictor *pred)
 				okay = false;
 			}
 
-			if (opt_debug && new_digest != old_digest) {
-				if (new_digest->size == old_digest->size
-				 && !memcmp(new_digest->data, old_digest->data, old_digest->size)) {
-					debug("Digest for %s did not change\n", description);
-				} else {
-					debug("Digest for %s changed\n", description);
-					debug("  Old digest: %s\n", digest_print(old_digest));
+			if (opt_debug) {
+				if (ev->synthetic) {
+					debug("New synthetic event for %s\n", description);
 					debug("  New digest: %s\n", digest_print(new_digest));
+				} else if (new_digest != old_digest) {
+					if (new_digest->size == old_digest->size
+					 && !memcmp(new_digest->data, old_digest->data, old_digest->size)) {
+						debug("Digest for %s did not change\n", description);
+					} else {
+						debug("Digest for %s changed\n", description);
+						debug("  Old digest: %s\n", digest_print(old_digest));
+						debug("  New digest: %s\n", digest_print(new_digest));
+					}
 				}
 			}
 

--- a/src/oracle.c
+++ b/src/oracle.c
@@ -231,7 +231,7 @@ static void
 predictor_load_eventlog(struct predictor *pred)
 {
 	tpm_event_log_reader_t *log;
-	tpm_event_t *ev, **tail;
+	tpm_event_t *ev, *prev = NULL, **tail;
 	uint8_t pcr0_locality;
 
 	log = event_log_open(pred->tpm_event_log_path);
@@ -241,6 +241,8 @@ predictor_load_eventlog(struct predictor *pred)
 	tail = &pred->event_log;
 	while ((ev = event_log_read_next(log)) != NULL) {
 		*tail = ev;
+		ev->prev = prev;
+		prev = ev;
 		tail = &ev->next;
 	}
 


### PR DESCRIPTION
To better support shim extra files, this patch series amends the directory search logic and introduces a mechanism to synthesize shim extra file events. Because system updates can add or remove these extra files dynamically, the legacy 1:1 event mapping prediction could be inaccurate. With these patches, pcr-oracle synthesizes the PCR 7 (shim authority) and PCR 4 (boot service application) events based on the actual extra files present on disk. It then flags the original hardware events as EVENT_STRATEGY_NO_ACTION to disable legacy event rehashing.

An additional option, `--disable-synthesis`, is also introduced to disable event synthesis to fall back to the 1:1 event mapping prediction.

Ref: https://github.com/openSUSE/pcr-oracle/issues/4