### PR TITLE
Update the SBAT offset boundary check

### DIFF
--- a/src/efi-variable.c
+++ b/src/efi-variable.c
@@ -118,7 +118,7 @@ parse_sbatlevel_section(buffer_t *sec,
 	 || !buffer_get_u32le(sec, &offset_latest))
 		return false;
 
-	if (offset_auto >= offset_latest)
+	if (offset_auto + 4 > offset_latest)
 		return false;
 
 	if (!buffer_seek_read(sec, offset_auto + 4))


### PR DESCRIPTION
The length calculation for the SBAT automatic string accounts for a 4-byte prefix. To prevent calculating an invalid or negative length, the boundary validation check has been updated to include this 4-byte prefix, ensuring the starting offset does not exceed the latest offset boundary.