### PR TITLE
Support TPM PCR snapshot on PowerPC 64 platform

### DIFF
--- a/src/eventlog.c
+++ b/src/eventlog.c
@@ -1089,7 +1089,7 @@ __tpm_event_parse_tag(tpm_event_t *ev, tpm_parsed_event_t *parsed, buffer_t *bp)
 	return true;
 }
 
-#define GRUB_PREP_ENVBLK "PReP ENV Block"
+#define GRUB_PREP_ENVBLK "PReP envblk"
 
 static bool
 __tpm_event_parse_ipl(tpm_event_t *ev, tpm_parsed_event_t *parsed, buffer_t *bp)

--- a/src/oracle.c
+++ b/src/oracle.c
@@ -80,7 +80,8 @@ struct predictor {
 	bool			disable_synthesis;
 };
 
-#define GRUB_PCR_SNAPSHOT_PATH	"/sys/firmware/efi/efivars/GrubPcrSnapshot-7ce323f2-b841-4d30-a0e9-5474a76c9a3f"
+#define GRUB_EFI_PCR_SNAPSHOT_PATH	"/sys/firmware/efi/efivars/GrubPcrSnapshot-7ce323f2-b841-4d30-a0e9-5474a76c9a3f"
+#define GRUB_DT_PCR_SNAPSHOT_PATH	"/sys/firmware/devicetree/base/chosen/grub,pcr-snapshot"
 
 enum {
 	OPT_FROM = 256,
@@ -196,7 +197,7 @@ usage(int exitval, const char *msg)
 		"Valid PCR sources for the --from and --verify options include:\n"
                 "  zero                   Initialize PCR state to all zero\n"
                 "  current                Set the PCR state to the current state of the host's PCR\n"
-                "  snapshot               Read the PCR state from a snapshot taken during boot (GrubPcrSnapshot EFI variable)\n"
+                "  snapshot               Read the PCR state from a snapshot taken during boot (GrubPcrSnapshot EFI variable or devicetree)\n"
                 "  eventlog               Predict the PCR state using the event log, by substituting current values. Only valid\n"
                 "                         as argument to --from.\n"
 		"\n"
@@ -220,9 +221,14 @@ pcr_bank_load_initial_values(tpm_pcr_bank_t *bank, unsigned int pcr_mask, const 
 		pcr_bank_init_from_zero(bank);
 	else if (!strcmp(source, "current"))
 		pcr_bank_init_from_current(bank);
-	else if (!strcmp(source, "snapshot"))
-		pcr_bank_init_from_snapshot(bank, GRUB_PCR_SNAPSHOT_PATH);
-	else
+	else if (!strcmp(source, "snapshot")) {
+		const char *path = GRUB_EFI_PCR_SNAPSHOT_PATH;
+
+		if (access(path, R_OK) != 0 && access(GRUB_DT_PCR_SNAPSHOT_PATH, R_OK) == 0)
+			path = GRUB_DT_PCR_SNAPSHOT_PATH;
+
+		pcr_bank_init_from_snapshot(bank, path);
+	} else
 		fatal("don't know how to load PCR bank with initial values: unsupported source \"%s\"\n", source);
 }
 

--- a/src/pcr.c
+++ b/src/pcr.c
@@ -205,20 +205,23 @@ pcr_bank_init_from_snapshot_fp(FILE *fp, tpm_pcr_bank_t *bank)
 }
 
 void
-pcr_bank_init_from_snapshot(tpm_pcr_bank_t *bank, const char *efivar_path)
+pcr_bank_init_from_snapshot(tpm_pcr_bank_t *bank, const char *snapshot_path)
 {
 	FILE *fp;
 	char buf[4];
 
-	debug("Trying to find PCR values in %s\n", efivar_path);
-	if (!(fp = fopen(efivar_path, "r")))
-		fatal("Unable to open \"%s\": %m\n", efivar_path);
+	debug("Trying to find PCR values in %s\n", snapshot_path);
+	if (!(fp = fopen(snapshot_path, "r")))
+		fatal("Unable to open \"%s\": %m\n", snapshot_path);
 
 	/* The efivarfs files are not seekable. Use fread() to skip over
-	 * 4 bytes of variable attributes
+	 * 4 bytes of variable attributes. Device tree or other regular files
+	 * do not have this attribute prefix.
 	 */
-	if (fread(buf, 1, 4, fp) != 4)
-		fatal("Unable to skip the first 4 bytes of %s\n", efivar_path);
+	if (strstr(snapshot_path, "/efivars/") != NULL) {
+		if (fread(buf, 1, 4, fp) != 4)
+			fatal("Unable to skip the first 4 bytes of %s\n", snapshot_path);
+	}
 
 	pcr_bank_init_from_snapshot_fp(fp, bank);
 }

--- a/src/pcr.h
+++ b/src/pcr.h
@@ -49,7 +49,7 @@ extern tpm_evdigest_t *	pcr_bank_get_register(tpm_pcr_bank_t *bank, unsigned int
 extern void		pcr_bank_set_locality(tpm_pcr_bank_t *bank, unsigned int index, uint8_t locality);
 extern void		pcr_bank_init_from_zero(tpm_pcr_bank_t *bank);
 extern void		pcr_bank_init_from_snapshot_fp(FILE *fp, tpm_pcr_bank_t *bank);
-extern void		pcr_bank_init_from_snapshot(tpm_pcr_bank_t *bank, const char *efivar_path);
+extern void		pcr_bank_init_from_snapshot(tpm_pcr_bank_t *bank, const char *snapshot_path);
 extern void		pcr_bank_init_from_current(tpm_pcr_bank_t *bank);
 
 extern bool		pcr_selection_valid_string(const char *);


### PR DESCRIPTION
The PCR snapshot support for PowerPC 64 is on the way to GRUB upstream(*). Update pcr-oracle to read the device tree property.

Also fix the string for GRUB PReP envblk event.

(*) https://gitlab.freedesktop.org/gnu-grub/grub/-/merge_requests/168