### PR TITLE
Add ecc-test to check for ECC P-256 support

### DIFF
--- a/man/pcr-oracle.8.in
+++ b/man/pcr-oracle.8.in
@@ -118,6 +118,9 @@ Perform a TPM self-test to verify the chip exists and works.
 Check whether the TPM supports a given RSA key length. The desired key
 length is given using the \fB--rsa-bits\fP option.
 .TP
+.B ecc-test
+Check whether the TPM supports ECC SRK keys.
+.TP
 .B predict
 Try to predict a specific set of PCR values.
 .TP

--- a/src/oracle.c
+++ b/src/oracle.c
@@ -47,6 +47,7 @@ enum {
 	ACTION_SIGN,
 	ACTION_SELFTEST,
 	ACTION_RSATEST,
+	ACTION_ECCTEST,
 };
 
 enum {
@@ -1130,6 +1131,7 @@ get_action_argument(int argc, char **argv)
 		{ "sign",			ACTION_SIGN	},
 		{ "self-test",			ACTION_SELFTEST	},
 		{ "rsa-test",			ACTION_RSATEST	},
+		{ "ecc-test",			ACTION_ECCTEST	},
 
 		{ NULL, 0 },
 	};
@@ -1420,6 +1422,10 @@ main(int argc, char **argv)
 		end_arguments(argc, argv);
 		break;
 
+	case ACTION_ECCTEST:
+		end_arguments(argc, argv);
+		break;
+
 	default:
 		fatal("Action %u not implemented\n", action);
 	}
@@ -1446,6 +1452,16 @@ main(int argc, char **argv)
 			return 0;
 		} else {
 			infomsg("RSA %u unsupported\n", rsa_bits);
+			return 1;
+		}
+	}
+
+	if (action == ACTION_ECCTEST) {
+		if (tpm_ecc_test()) {
+			infomsg("ECC P-256 supported\n");
+			return 0;
+		} else {
+			infomsg("ECC P-256 unsupported\n");
 			return 1;
 		}
 	}

--- a/src/oracle.h
+++ b/src/oracle.h
@@ -27,6 +27,7 @@ extern bool		ima_is_active(void);
 extern buffer_t *	platform_read_shim_vendor_cert(void);
 extern bool		tpm_selftest(bool fulltest);
 extern bool		tpm_rsa_bits_test(unsigned int rsa_bits);
+extern bool		tpm_ecc_test(void);
 
 #endif /* PCR_ORACLE_H */
 

--- a/src/tpm.c
+++ b/src/tpm.c
@@ -323,3 +323,28 @@ tpm_rsa_bits_test(unsigned int rsa_bits)
 
 	return okay;
 }
+
+bool
+tpm_ecc_test(void)
+{
+	ESYS_CONTEXT *esys_ctx = tss_esys_context();
+	TPMT_PUBLIC_PARMS parms = {0};
+	TSS2_RC rc;
+	bool okay = false;
+
+	/* Suppress the messages from tpm2-tss */
+	setenv("TSS2_LOG", "all+NONE", 1);
+
+	parms.type = TPM2_ALG_ECC;
+	memcpy(&parms.parameters, &ECC_SRK_template.publicArea.parameters,
+	       sizeof(TPMU_PUBLIC_PARMS));
+
+	rc = Esys_TestParms(esys_ctx, ESYS_TR_NONE, ESYS_TR_NONE,
+			ESYS_TR_NONE, &parms);
+	if (rc == TSS2_RC_SUCCESS)
+		okay = true;
+	else if (rc != (TPM2_RC_VALUE | TPM2_RC_P | TPM2_RC_1))
+		tss_check_error(rc, "Esys_TestParms failed");
+
+	return okay;
+}


### PR DESCRIPTION
Similar to 'rsa-test', 'ecc-test' utilizes the 'TPM2_TestParms' command to verify whether ECC P-256 is supported by the hardware chip.