### PR TITLE
Make `.dir_list` optional

### DIFF
--- a/src/testcase.c
+++ b/src/testcase.c
@@ -379,7 +379,7 @@ testcase_playback_efi_directory(testcase_t *tc, const char *partition, const cha
 	partition = get_basename(partition);
 
 	snprintf(path, sizeof(path), "%s/%s/.dir_list", partition, directory);
-	return testcase_read_file(tc->bsa_directory, path);
+	return __testcase_read_file(tc->bsa_directory, path, RUNTIME_MISSING_FILE_OKAY);
 }
 
 void


### PR DESCRIPTION
The `.dir_list` file was introduced to preserve file order in the EFI system partition when replaying test cases. Because older test cases may not contain this file, it should not be required during replay.